### PR TITLE
[Add] onDisable and remove wirerod recipe in it

### DIFF
--- a/src/main/java/com/github/ucchyocean/WireRod.java
+++ b/src/main/java/com/github/ucchyocean/WireRod.java
@@ -40,6 +40,15 @@ public class WireRod extends JavaPlugin {
         }
     }
 
+    /**
+     * プラグインが無効化されたときに呼び出されるメソッド
+     *
+     * @see org.bukkit.plugin.java.JavaPlugin#onEnable()
+     */
+    public void onDisable() {
+        WireRodUtil.removeRecipe();
+    }
+
     static WireRod getInstance() {
         if (instance == null) {
             instance = JavaPlugin.getPlugin(WireRod.class);


### PR DESCRIPTION
[プラグインの有効化・無効化を管理するプラグイン](https://dev.bukkit.org/projects/plugman)などで、このプラグインを扱えるようにするため、レシピをプラグインの無効化時に削除するようにしました。